### PR TITLE
Fix use of deprecated method

### DIFF
--- a/src/MagentoHackathon/Composer/Command/Slot.php
+++ b/src/MagentoHackathon/Composer/Command/Slot.php
@@ -25,8 +25,8 @@ class Slot extends \Composer\Console\Application
 
         $commands = array( new ListCommand());
         
-        $repositories = $this->getComposer()->getRepositoryManager()->getLocalRepositories();
-        foreach( $repositories[0]->getPackages() as $package ){
+        $repository = $this->getComposer()->getRepositoryManager()->getLocalRepository();
+        foreach( $repository->getPackages() as $package ){
 
             $extra = $package->getExtra();
             if( isset($extra['composer-command-registry']) ){


### PR DESCRIPTION
In some version of Composer they deprecated the use of RepositoryManager->getLocalRepositories and instead throws an error.
This pull request fixes the issue and use the getLocalRepository method instead.
