### PR TITLE
Fix #10 Deprecation Warnings

### DIFF
--- a/bin/composerCommandIntegrator.php
+++ b/bin/composerCommandIntegrator.php
@@ -2,29 +2,33 @@
 <?php
 
 
-if ((!@include __DIR__.'/../../../autoload.php') && (!@include __DIR__.'/../vendor/autoload.php')) {
-    die('You must set up the project dependencies, run the following commands:'.PHP_EOL.
-        'curl -s http://getcomposer.org/installer | php'.PHP_EOL.
-        'php composer.phar install'.PHP_EOL);
+if ((!@include __DIR__ . '/../../../autoload.php') && (!@include __DIR__ . '/../vendor/autoload.php')) {
+    die('You must set up the project dependencies, run the following commands:' . PHP_EOL .
+        'curl -s http://getcomposer.org/installer | php' . PHP_EOL .
+        'php composer.phar install' . PHP_EOL);
+}
+
+$questionHelper = class_exists('\Symfony\Component\Console\Helper\QuestionHelper')
+    ? '\Symfony\Component\Console\Helper\QuestionHelper'
+    : '\Symfony\Component\Console\Helper\DialogHelper'; // is deprecated since version 2.5 and will be removed in 3.0.
+
+$helperSet = array(
+    new $questionHelper(),
+    new \Symfony\Component\Console\Helper\FormatterHelper(),
+);
+
+if (false === class_exists('\Symfony\Component\Console\Helper\ProgressBar')) {
+    // is deprecated since version 2.5 and will be removed in 3.0.
+    $helperSet[] = new \Symfony\Component\Console\Helper\ProgressHelper();
 }
 
 $consoleIO = new \Composer\IO\ConsoleIO(
     new \Symfony\Component\Console\Input\ArgvInput(),
     new \Symfony\Component\Console\Output\ConsoleOutput(),
-    new \Symfony\Component\Console\Helper\HelperSet(
-        array(
-            new \Symfony\Component\Console\Helper\DialogHelper(),
-            new \Symfony\Component\Console\Helper\FormatterHelper(),
-            new \Symfony\Component\Console\Helper\ProgressHelper()
-        )
-    )
-
+    new \Symfony\Component\Console\Helper\HelperSet($helperSet)
 );
-$nullIO = new  \Composer\IO\NullIO();
 
 $composer = \Composer\Factory::create($consoleIO);
 
-
 $application = new \MagentoHackathon\Composer\Command\Slot($composer);
 $application->run();
-


### PR DESCRIPTION
Temporary implementation.
This code can be removed if we have reached version 3.0.

`ProgressBar` cannot be used anymore as a HelperSet hence removed.

If something is weird please comment :+1: 